### PR TITLE
feat: expose `SymWidgetState` to direct state access

### DIFF
--- a/packages/flutter_sym/example/lib/counter_widget.dart
+++ b/packages/flutter_sym/example/lib/counter_widget.dart
@@ -16,13 +16,18 @@ final counter = Module(name: 'counter', ($) {
   );
 });
 
-class CounterWidget extends SymWidget {
+class CounterWidget extends StatefulWidget {
   const CounterWidget({
     super.key,
   });
 
   @override
-  Widget build(SymBuildContext context) {
+  State<StatefulWidget> createState() => _CounterWidgetState();
+}
+
+class _CounterWidgetState extends SymWidgetState<CounterWidget> {
+  @override
+  Widget buildWidget(SymBuildContext context) {
     final (:increment, :value) = context.use(counter);
 
     return Center(

--- a/packages/flutter_sym/example/lib/home_page.dart
+++ b/packages/flutter_sym/example/lib/home_page.dart
@@ -8,13 +8,18 @@ final homeScreen = Module(name: 'homeScreen', ($) {
   return (showCounter: showCounter,);
 });
 
-class MyHomePage extends SymWidget {
+class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
 
   final String title;
 
   @override
-  Widget build(SymBuildContext context) {
+  SymWidgetState createState() => _HomePageState();
+}
+
+class _HomePageState extends SymWidgetState<MyHomePage> {
+  @override
+  Widget buildWidget(SymBuildContext context) {
     final (:showCounter) = context.use(homeScreen);
 
     final shouldShow = context.use(showCounter.get);
@@ -22,7 +27,7 @@ class MyHomePage extends SymWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(title),
+        title: Text(widget.title),
       ),
       body: Center(
         child: Column(

--- a/packages/flutter_sym/example/lib/random_user_page.dart
+++ b/packages/flutter_sym/example/lib/random_user_page.dart
@@ -2,13 +2,18 @@ import 'random_user.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sym/flutter_sym.dart';
 
-class RandomUserPage extends SymWidget {
+class RandomUserPage extends StatefulWidget {
   const RandomUserPage({
     super.key,
   });
 
   @override
-  Widget build(SymBuildContext context) {
+  State<StatefulWidget> createState() => _RandomUserPageState();
+}
+
+class _RandomUserPageState extends SymWidgetState<RandomUserPage> {
+  @override
+  Widget buildWidget(SymBuildContext context) {
     final m = context.use(randomUser);
     final control = m.control;
     final user = context.use(m.user);
@@ -24,23 +29,17 @@ class RandomUserPage extends SymWidget {
                   const Text('Keep updated'),
                   Checkbox(
                     value: context.use(control.keepUpdated.get),
-                    onChanged: isLoading
-                        ? null
-                        : (value) => control.keepUpdated.set(context, value!),
+                    onChanged: isLoading ? null : (value) => control.keepUpdated.set(context, value!),
                   ),
                 ],
               ),
               SegmentedButton<Gender>(
-                segments: Gender.values
-                    .map((gender) =>
-                        ButtonSegment(value: gender, label: Text(gender.name)))
-                    .toList(),
+                segments:
+                    Gender.values.map((gender) => ButtonSegment(value: gender, label: Text(gender.name))).toList(),
                 selected: {
                   context.use(control.gender.get),
                 },
-                onSelectionChanged: isLoading
-                    ? null
-                    : (genders) => control.gender.set(context, genders.first),
+                onSelectionChanged: isLoading ? null : (genders) => control.gender.set(context, genders.first),
               ),
             ],
           ),

--- a/packages/flutter_sym/lib/src/sym_builder.dart
+++ b/packages/flutter_sym/lib/src/sym_builder.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_sym/src/sym_build_context.dart';
 import 'package:flutter_sym/src/sym_widget.dart';
 
-class SymBuilder extends SymWidget {
+class SymBuilder extends StatefulWidget {
   final Widget Function(SymBuildContext context) builder;
 
   const SymBuilder({
@@ -11,5 +11,10 @@ class SymBuilder extends SymWidget {
   });
 
   @override
-  Widget build(SymBuildContext context) => builder(context);
+  SymWidgetState createState() => _SymBuilderState();
+}
+
+class _SymBuilderState extends SymWidgetState<SymBuilder> {
+  @override
+  Widget buildWidget(SymBuildContext context) => widget.builder(context);
 }

--- a/packages/flutter_sym/lib/src/sym_widget.dart
+++ b/packages/flutter_sym/lib/src/sym_widget.dart
@@ -1,34 +1,30 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_sym/src/module_manager_state_mixin.dart';
 import 'package:flutter_sym/src/sym_build_context.dart';
 import 'package:sym/sym.dart';
 
-abstract class SymWidget extends StatefulWidget {
-  const SymWidget({super.key});
-
-  Widget build(SymBuildContext context);
-
-  @override
-  State<SymWidget> createState() => _SymWidgetState();
-}
-
-class _SymWidgetState extends State<SymWidget>
-    with ModuleManagerStateMixin<SymWidget, Store<Widget>> {
+abstract class SymWidgetState<W extends StatefulWidget> extends State<W>
+    with ModuleManagerStateMixin<W, Store<Widget>> {
   SymBuildContextImplementation? _debugSymContext;
   Widget? _debugHotReloadAwareChild;
 
+  Widget buildWidget(SymBuildContext context);
+
   @override
+  @nonVirtual
   void reassemble() {
     super.reassemble();
     if (patchHotReload) {
-      _debugHotReloadAwareChild = widget.build(_debugSymContext!);
+      _debugHotReloadAwareChild = buildWidget(_debugSymContext!);
     }
   }
 
   bool get patchHotReload => true;
 
   @override
-  Module<Store<Widget>> createModule() => Module(name: 'SymWidget', ($) {
+  @nonVirtual
+  Module<Store<Widget>> createModule() => Module(name: 'SymWidget($W)', ($) {
         final result = $.value((valueSym) {
           final symContext = SymBuildContextImplementation(
             runtime,
@@ -36,7 +32,7 @@ class _SymWidgetState extends State<SymWidget>
             valueSym,
             context,
           );
-          final built = widget.build(symContext);
+          final built = buildWidget(symContext);
 
           if (patchHotReload) {
             _debugSymContext = symContext;
@@ -53,6 +49,7 @@ class _SymWidgetState extends State<SymWidget>
       });
 
   @override
+  @nonVirtual
   Widget build(BuildContext context) {
     final use = runtime.use;
     final output = use(use(module));


### PR DESCRIPTION
expose the `SymWidgetState` class for Flutter-style interaction with the state itself

this allows us to use common state mixins, such as the `SingleTickerProviderMixin`